### PR TITLE
Allowing context and user to be tested values

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,25 @@ var sandbox_function_template = (function () {
   /*
    require('auth0-authz-rules-api').extend(global);
    return function (ctx, cb) {
-   var console = _wrap_console();
-   var configuration = <%- JSON.stringify(model.configuration) %>;
-   var webtask = ctx;
-   (<%- model.script %>)(<%- model.args %>, _wrap_callback(cb, console));
+     var console = _wrap_console();
+     var configuration = <%- JSON.stringify(model.configuration) %>;
+     var webtask = ctx;
+
+     var resultAggregate = function(error, user, context) {
+       if (error) { return cb(error); }
+       return cb(error, { user: user, context: context});
+     };
+
+     (
+       function (usr, ctx, cb) {
+        var manipulator = function(error, user, context) {
+          if(error) { return cb(error); }
+          return cb(error, { user: usr, context: ctx });
+        };
+        
+        (<%- model.script %>)(usr, ctx, manipulator);
+      }
+     )(<%- model.args %>, _wrap_callback(cb, console));
    }
    */
 }).toString().match(/[^]*\/\*([^]*)\*\/\s*\}$/)[1];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-rules-testharness",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "deploy, execute, and test the output of Auth0 Rules using a webtask sandbox environment.",
   "author": "Richard Seldon<arcseldon@gmail.com>",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-rules-testharness",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "deploy, execute, and test the output of Auth0 Rules using a webtask sandbox environment.",
   "author": "Richard Seldon<arcseldon@gmail.com>",
   "main": "./index.js",


### PR DESCRIPTION
Currently, we cannot test the context object.  To get around this limitation we must merge user and context into a single object.  The /run webtask endpoint can only handle a callback with two arguments `callback(error, arg1)`.  If the webtask's callback looks like this `callback(error, arg1, arg2)` arg1 will be stringified, but arg2 will be ignored.